### PR TITLE
[fix] auth api 오류 해결 및 nickname 저장

### DIFF
--- a/app/src/main/java/konkuk/link/bokbookbok/MainActivity.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/MainActivity.kt
@@ -12,11 +12,13 @@ import androidx.navigation.compose.rememberNavController
 import konkuk.link.bokbookbok.navigation.RootNavHost
 import konkuk.link.bokbookbok.ui.theme.BOKBOOKBOKTheme
 import konkuk.link.bokbookbok.util.TokenManager
+import konkuk.link.bokbookbok.util.UserManager
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         TokenManager.init(this)
+        UserManager.init(this)
         enableEdgeToEdge()
         setContent {
             BOKBOOKBOKTheme {

--- a/app/src/main/java/konkuk/link/bokbookbok/data/model/response/login/LoginResponse.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/data/model/response/login/LoginResponse.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class LoginResponse(
     val userId: Int,
+    val nickname: String,
     val jwtToken: JwtToken,
 )

--- a/app/src/main/java/konkuk/link/bokbookbok/data/remote/ApiException.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/data/remote/ApiException.kt
@@ -1,5 +1,0 @@
-package konkuk.link.bokbookbok.data.remote
-
-class ApiException(
-    message: String,
-) : Exception(message)

--- a/app/src/main/java/konkuk/link/bokbookbok/data/repository/AuthRepository.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/data/repository/AuthRepository.kt
@@ -1,18 +1,14 @@
 package konkuk.link.bokbookbok.data.repository
 
-import android.net.http.HttpException
 import konkuk.link.bokbookbok.data.model.request.login.LoginRequest
 import konkuk.link.bokbookbok.data.model.request.register.RegisterEmailRequest
 import konkuk.link.bokbookbok.data.model.request.register.RegisterNicknameRequest
 import konkuk.link.bokbookbok.data.model.request.register.RegisterRequest
-import konkuk.link.bokbookbok.data.model.response.BaseResponse
 import konkuk.link.bokbookbok.data.model.response.login.LoginResponse
 import konkuk.link.bokbookbok.data.model.response.register.RegisterEmailResponse
 import konkuk.link.bokbookbok.data.model.response.register.RegisterNicknameResponse
 import konkuk.link.bokbookbok.data.model.response.register.RegisterResponse
-import konkuk.link.bokbookbok.data.remote.ApiException
 import konkuk.link.bokbookbok.data.remote.ApiService
-import kotlinx.serialization.json.Json
 
 class AuthRepository(
     private val apiService: ApiService,
@@ -23,37 +19,5 @@ class AuthRepository(
 
     suspend fun registerNicknameUser(request: RegisterNicknameRequest): Result<RegisterNicknameResponse> = safeApiCall { apiService.registerNicknameDuplicate(request) }
 
-    suspend fun loginUser(request: LoginRequest): Result<LoginResponse> =
-        try {
-            val response = apiService.login(request)
-
-            if (response.code == 200 && response.data != null) {
-                Result.success(response.data)
-            } else {
-                Result.failure(ApiException(response.msg))
-            }
-        } catch (e: Exception) {
-            when (e) {
-                is HttpException -> {
-                    val errorMsg = parseErrorBody(e)
-                    Result.failure(ApiException(errorMsg))
-                }
-                else -> {
-                    Result.failure(e)
-                }
-            }
-        }
+    suspend fun loginUser(request: LoginRequest): Result<LoginResponse> = safeApiCall { apiService.login(request) }
 }
-
-private fun parseErrorBody(e: HttpException): String =
-    try {
-        val errorBodyString = e.toString()
-        if (errorBodyString != null) {
-            val errorResponse = Json.decodeFromString<BaseResponse<Unit>>(errorBodyString)
-            errorResponse.msg
-        } else {
-            "알 수 없는 오류가 발생했습니다."
-        }
-    } catch (jsonError: Exception) {
-        "오류 응답을 처리할 수 없습니다."
-    }

--- a/app/src/main/java/konkuk/link/bokbookbok/screen/auth/LoginViewModel.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/screen/auth/LoginViewModel.kt
@@ -7,6 +7,7 @@ import konkuk.link.bokbookbok.data.model.request.login.LoginRequest
 import konkuk.link.bokbookbok.data.model.response.login.LoginResponse
 import konkuk.link.bokbookbok.data.repository.AuthRepository
 import konkuk.link.bokbookbok.util.TokenManager
+import konkuk.link.bokbookbok.util.UserManager
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -44,10 +45,12 @@ class LoginViewModel(
                 .onSuccess { response: LoginResponse ->
                     val accessToken = response.jwtToken.accessToken
                     TokenManager.saveAccessToken(accessToken)
+                    val nickname = response.nickname
+                    UserManager.saveNickname(nickname)
                     _loginErrorMessage.value = null
                     _loginSuccessEvent.emit(Unit)
                 }.onFailure { error ->
-                    _loginErrorMessage.value = error.message
+                    _loginErrorMessage.value = "등록되지 않은 아이디거나 잘못 입력했습니다."
                 }
         }
     }

--- a/app/src/main/java/konkuk/link/bokbookbok/util/UserManager.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/util/UserManager.kt
@@ -1,0 +1,32 @@
+package konkuk.link.bokbookbok.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.core.content.edit
+
+object UserManager {
+    private const val PREFS_NICKNAME = "nickname_prefs"
+    private const val USER_NICKNAME = "nickname"
+
+    private lateinit var sharedPreferences: SharedPreferences
+
+    fun init(context: Context) {
+        sharedPreferences = context.getSharedPreferences(UserManager.PREFS_NICKNAME, Context.MODE_PRIVATE)
+    }
+
+    fun saveNickname(nickname: String) {
+        sharedPreferences.edit {
+            putString(USER_NICKNAME, nickname)
+        }
+        Log.d("UserManager", "Nickname saved: $nickname")
+    }
+
+    fun getNickname(): String? = sharedPreferences.getString(USER_NICKNAME, null)
+
+    fun clearNickname() {
+        sharedPreferences.edit {
+            remove(USER_NICKNAME)
+        }
+    }
+}

--- a/app/src/main/java/konkuk/link/bokbookbok/util/UserManager.kt
+++ b/app/src/main/java/konkuk/link/bokbookbok/util/UserManager.kt
@@ -12,7 +12,7 @@ object UserManager {
     private lateinit var sharedPreferences: SharedPreferences
 
     fun init(context: Context) {
-        sharedPreferences = context.getSharedPreferences(UserManager.PREFS_NICKNAME, Context.MODE_PRIVATE)
+        sharedPreferences = context.getSharedPreferences(PREFS_NICKNAME, Context.MODE_PRIVATE)
     }
 
     fun saveNickname(nickname: String) {


### PR DESCRIPTION
## 📄 Tasks

1. sharedPreferences에 nickname 저장하는 UserManager 생성
2. 로그인 에러 문구 처리 변경

## ⭐ PR Point (To Reviewer)

1. user 정보 전역으로 관리해야하는 것이 있다면 UserManager로 통합?,,

## 📷 Screenshot
<img width="245" height="240" alt="image" src="https://github.com/user-attachments/assets/f75cd5e4-71db-484e-9e58-f7b5beddd064" />


## 🔔 ETC
